### PR TITLE
Service test

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ You can run the service directly with SBT via `sbt run` or by running the docker
 
 ## Tests
 
-Tests are executed via `sbt test`
+`sbt test` to run the unit tests.
+
+`sbt dockerComposeTest` to run the service tests. These involve running the service and its dependencies (Kafka, ZooKeeper and a fake S3 API) using docker-compose.
 
 ## Deployment
 

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,11 @@ testTagsToExecute := "DockerComposeTag"
 
 dockerImageCreationTask := (publishLocal in Docker).value
 
-lazy val ipAddress: String = "./get_ip_address.sh".!!.trim
+lazy val ipAddress: String = {
+  val addr = "./get_ip_address.sh".!!.trim
+  println(s"My IP address appears to be $addr")
+  addr
+}
 
 variablesForSubstitution := Map("IP_ADDRESS" -> ipAddress)
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalacOptions := Seq("-unchecked", "-deprecation", "-feature", "-encoding", "utf
 
 // Make ScalaTest write test reports that CircleCI understands
 val testReportsDir = sys.env.getOrElse("CI_REPORTS", "target/reports")
-testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-o", "-u", testReportsDir)
+testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oF", "-u", testReportsDir, "-l", "DockerComposeTag")
 
 resolvers += Resolver.bintrayRepo("ovotech", "maven")
 resolvers += Resolver.bintrayRepo("cakesolutions", "maven")
@@ -23,10 +23,16 @@ libraryDependencies ++= Seq(
   "com.chuusai" %% "shapeless" % "2.3.2",
   "ch.qos.logback" % "logback-classic" % "1.1.7",
   "io.logz.logback" % "logzio-logback-appender" % "1.0.11",
-  "org.scalatest" %% "scalatest" % "3.0.1" % Test
+  "org.scalatest" %% "scalatest" % "3.0.1" % Test,
+  "org.apache.kafka" %% "kafka" % "0.10.0.1" % Test
 )
 
 scalafmtConfig in ThisBuild := Some(file(".scalafmt.conf"))
 reformatOnCompileSettings
+
+// Service tests
+enablePlugins(DockerComposePlugin)
+testTagsToExecute := "DockerComposeTag"
+dockerImageCreationTask := (publishLocal in Docker).value
 
 lazy val root = (project in file(".")).withDocker

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+  pre:
+    - curl -sSL https://s3.amazonaws.com/circle-downloads/install-circleci-docker.sh | bash -s -- 1.10.0
   services:
     - docker
 

--- a/circle.yml
+++ b/circle.yml
@@ -15,8 +15,9 @@ dependencies:
     - "project/target/resolution-cache"
 
 test:
-  post:
-    - sbt docker:publishLocal
+  override:
+    - sbt test
+    - sbt dockerComposeTest
 
 deployment:
   uat_and_prd:

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,8 @@ checkout:
     - git submodule update --init --remote
 
 dependencies:
+  pre:
+    - sudo pip install docker-compose
   # Cache the resolution-cache and build streams to speed things up
   cache_directories:
     - "~/.sbt"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     environment:
       ENV: LOCAL
       KAFKA_HOSTS: kafka:29092
+      DOCKER_COMPOSE: "true"
 
   fakes3:
     image: lphoward/fake-s3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+version: '2'
+
+services:
+
+  composer:
+    image: ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-1.amazonaws.com/composer:0.1-SNAPSHOT
+    depends_on:
+      - kafka
+      - fakes3ssl
+    links:
+      - kafka
+      - fakes3ssl:ovo-comms-templates.s3-eu-west-1.amazonaws.com
+    environment:
+      ENV: LOCAL
+      KAFKA_HOSTS: kafka:29092
+
+  fakes3:
+    image: lphoward/fake-s3
+    ports:
+      - "4569:4569"
+
+  fakes3ssl:
+    image: cbachich/ssl-proxy
+    depends_on:
+      - fakes3
+    ports:
+      - "443:443"
+    links:
+      - fakes3:proxyapp
+    environment:
+      - PORT=443
+      - TARGET_PORT=4569
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:3.1.1
+    ports:
+      - "32181:32181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 32181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: confluentinc/cp-kafka:3.1.1
+    ports:
+     - "29092:29092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:32181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://10.42.34.53:29092
+    depends_on:
+      - zookeeper

--- a/get_ip_address.sh
+++ b/get_ip_address.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Get the first non-loopback address of the machine
 
-export IP_ADDRESS="$(ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')"
+export IP_ADDRESS="$(ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | head -n 1)"
 echo -n $IP_ADDRESS

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.4")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.4.10")
+addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.13")

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -31,6 +31,11 @@ akka.kafka.producer {
   use-dispatcher = "akka.kafka.default-dispatcher"
 }
 
+akka.kafka.consumer {
+  wakeup-timeout = 5s
+  max-wakeups = 24
+}
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]

--- a/src/main/scala/com/ovoenergy/comms/Logging.scala
+++ b/src/main/scala/com/ovoenergy/comms/Logging.scala
@@ -16,6 +16,10 @@ trait Logging {
     withMDC(transactionId)(log.warn(message))
   }
 
+  def warnE(transactionId: String)(message: String, exception: Throwable): Unit = {
+    withMDC(transactionId)(log.warn(message, exception))
+  }
+
   private def withMDC(transactionId: String)(block: => Unit): Unit = {
     MDC.put(TransactionId, transactionId)
     try {

--- a/src/main/scala/com/ovoenergy/comms/Main.scala
+++ b/src/main/scala/com/ovoenergy/comms/Main.scala
@@ -1,9 +1,5 @@
 package com.ovoenergy.comms
 
-import java.net.InetAddress
-import java.time.OffsetDateTime
-import java.util.UUID
-
 import akka.actor.ActorSystem
 import akka.kafka.ConsumerSettings
 import akka.stream.{ActorAttributes, ActorMaterializer, Supervision}
@@ -15,35 +11,36 @@ import com.typesafe.config.ConfigFactory
 import org.slf4j.LoggerFactory
 import com.ovoenergy.comms.kafka.{Kafka, Serialization}
 import cats.instances.either._
-import com.amazonaws.auth.{
-  AWSCredentialsProviderChain,
-  AWSStaticCredentialsProvider,
-  BasicAWSCredentials,
-  ContainerCredentialsProvider
-}
+import com.amazonaws.auth._
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.Regions
-import com.amazonaws.services.s3.{AmazonS3Client, S3ClientOptions}
+import com.amazonaws.services.s3.AmazonS3Client
 import com.ovoenergy.comms.email.{Composer, Interpreter}
 import com.ovoenergy.comms.repo.AmazonS3ClientWrapper
 
-import scala.util.control.NonFatal
-
 object Main extends App {
 
-  // TODO only do this in service tests
-  System.setProperty("com.amazonaws.sdk.disableCertChecking", "true")
+  val runningInDockerCompose = sys.env.get("DOCKER_COMPOSE").contains("true")
+
+  if (runningInDockerCompose) {
+    // accept the self-signed certs from the SSL proxy sitting in front of the fake S3 container
+    System.setProperty("com.amazonaws.sdk.disableCertChecking", "true")
+  }
 
   val log = LoggerFactory.getLogger(getClass)
 
   val config = ConfigFactory.load()
 
   val s3Client: AmazonS3ClientWrapper = {
-    val awsCredentials = new AWSCredentialsProviderChain(
-      new ContainerCredentialsProvider(),
-      new ProfileCredentialsProvider(),
-      new AWSStaticCredentialsProvider(new BasicAWSCredentials("service-test", "dummy"))
-    )
+    val awsCredentials: AWSCredentialsProvider = {
+      if (runningInDockerCompose)
+        new AWSStaticCredentialsProvider(new BasicAWSCredentials("service-test", "dummy"))
+      else
+        new AWSCredentialsProviderChain(
+          new ContainerCredentialsProvider(),
+          new ProfileCredentialsProvider()
+        )
+    }
     val underlying: AmazonS3Client =
       new AmazonS3Client(awsCredentials).withRegion(Regions.fromName(config.getString("aws.region")))
     new AmazonS3ClientWrapper(underlying)
@@ -80,25 +77,8 @@ object Main extends App {
 
   val interpreterFactory = Interpreter.build(s3Client) _
   val emailStream = Kafka.buildStream(input, composedEmailEventOutput, failedEmailEventOutput) { orchestratedEmail =>
-    try {
-      val interpreter = interpreterFactory(orchestratedEmail)
-      Composer.program(orchestratedEmail).foldMap(interpreter)
-    } catch {
-      case NonFatal(e) =>
-        log.info(s"OH NO! ", e)
-        Left(
-          Failed(Metadata(
-                   OffsetDateTime.now().toString,
-                   UUID.randomUUID(),
-                   orchestratedEmail.metadata.customerId,
-                   orchestratedEmail.metadata.transactionId,
-                   orchestratedEmail.metadata.friendlyDescription,
-                   "comms-composer",
-                   orchestratedEmail.metadata.canary,
-                   Some(orchestratedEmail.metadata)
-                 ),
-                 e.getMessage))
-    }
+    val interpreter = interpreterFactory(orchestratedEmail)
+    Composer.program(orchestratedEmail).foldMap(interpreter)
   }
 
   val decider: Supervision.Decider = { e =>

--- a/src/main/scala/com/ovoenergy/comms/email/Interpreter.scala
+++ b/src/main/scala/com/ovoenergy/comms/email/Interpreter.scala
@@ -8,45 +8,64 @@ import cats.~>
 import com.ovoenergy.comms._
 import com.ovoenergy.comms.repo.{S3Client, S3TemplateRepo}
 
+import scala.util.control.NonFatal
+
 object Interpreter extends Logging {
 
   type FailedOr[A] = Either[Failed, A]
 
   def build(s3client: S3Client)(incomingEvent: OrchestratedEmail): ComposerA ~> FailedOr =
     new (ComposerA ~> FailedOr) {
-      override def apply[A](op: ComposerA[A]): FailedOr[A] = op match {
-        case RetrieveTemplate(channel, commManifest) =>
-          // only supporting email for now
-          S3TemplateRepo.getEmailTemplate(commManifest).run(s3client).leftMap(reason => fail(reason, incomingEvent))
-        case Render(commManifest, template, data, customerProfile, recipientEmailAddress) =>
-          Rendering
-            .renderEmail(Clock.systemDefaultZone())(commManifest,
-                                                    template,
-                                                    data,
-                                                    customerProfile,
-                                                    recipientEmailAddress)
-            .leftMap(reason => fail(reason, incomingEvent))
-        case LookupSender(template, commType) =>
-          Right(SenderLogic.chooseSender(template, commType))
+      override def apply[A](op: ComposerA[A]): FailedOr[A] = {
+        try {
+          op match {
+            case RetrieveTemplate(channel, commManifest) =>
+              // only supporting email for now
+              S3TemplateRepo
+                .getEmailTemplate(commManifest)
+                .run(s3client)
+                .leftMap(reason => fail(reason, incomingEvent))
+            case Render(commManifest, template, data, customerProfile, recipientEmailAddress) =>
+              Rendering
+                .renderEmail(Clock.systemDefaultZone())(commManifest,
+                                                        template,
+                                                        data,
+                                                        customerProfile,
+                                                        recipientEmailAddress)
+                .leftMap(reason => fail(reason, incomingEvent))
+            case LookupSender(template, commType) =>
+              Right(SenderLogic.chooseSender(template, commType))
+          }
+        } catch {
+          case NonFatal(e) => Left(failWithException(e, incomingEvent))
+        }
       }
     }
 
   private def fail(reason: String, incomingEvent: OrchestratedEmail): Failed = {
     warn(incomingEvent.metadata.transactionId)(s"Failed to compose email. Reason: $reason")
-    Failed(
-      // TODO add a convenience constructor to Metadata in comms-kafka-messages
-      Metadata(
-        OffsetDateTime.now().toString,
-        UUID.randomUUID(),
-        incomingEvent.metadata.customerId,
-        incomingEvent.metadata.transactionId,
-        incomingEvent.metadata.friendlyDescription,
-        "comms-composer",
-        incomingEvent.metadata.canary,
-        Some(incomingEvent.metadata)
-      ),
-      reason
-    )
+    buildFailedEvent(reason, incomingEvent)
   }
+
+  private def failWithException(exception: Throwable, incomingEvent: OrchestratedEmail): Failed = {
+    warnE(incomingEvent.metadata.transactionId)(s"Failed to compose email because an unexpected exception occurred",
+                                                exception)
+    buildFailedEvent(s"Exception occurred ($exception)", incomingEvent)
+  }
+
+  private def buildFailedEvent(reason: String, incomingEvent: OrchestratedEmail): Failed = Failed(
+    // TODO add a convenience constructor to Metadata in comms-kafka-messages
+    Metadata(
+      OffsetDateTime.now().toString,
+      UUID.randomUUID(),
+      incomingEvent.metadata.customerId,
+      incomingEvent.metadata.transactionId,
+      incomingEvent.metadata.friendlyDescription,
+      "comms-composer",
+      incomingEvent.metadata.canary,
+      Some(incomingEvent.metadata)
+    ),
+    reason
+  )
 
 }

--- a/src/main/scala/com/ovoenergy/comms/kafka/Serialization.scala
+++ b/src/main/scala/com/ovoenergy/comms/kafka/Serialization.scala
@@ -20,7 +20,7 @@ object Serialization {
   val composedEmailSerializer = avroSerializer[ComposedEmail]
   val failedSerializer = avroSerializer[Failed]
 
-  private def avroDeserializer[T: SchemaFor: FromRecord: ClassTag]: Deserializer[Option[T]] =
+  def avroDeserializer[T: SchemaFor: FromRecord: ClassTag]: Deserializer[Option[T]] =
     new Deserializer[Option[T]] {
       override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = {}
       override def close(): Unit = {}
@@ -43,7 +43,7 @@ object Serialization {
       }
     }
 
-  private def avroSerializer[T: SchemaFor: ToRecord]: Serializer[T] =
+  def avroSerializer[T: SchemaFor: ToRecord]: Serializer[T] =
     new Serializer[T] {
       override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = {}
       override def close(): Unit = {}

--- a/src/test/scala/com/ovoenergy/comms/ServiceSpec.scala
+++ b/src/test/scala/com/ovoenergy/comms/ServiceSpec.scala
@@ -1,0 +1,155 @@
+package com.ovoenergy.comms
+
+import java.time.OffsetDateTime
+import java.util
+import java.util.UUID
+
+import cakesolutions.kafka._
+import cakesolutions.kafka.KafkaProducer.{Conf => ProdConf}
+import cakesolutions.kafka.KafkaConsumer.{Conf => ConsConf}
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.s3.{AmazonS3Client, S3ClientOptions}
+import com.ovoenergy.comms.kafka.Serialization
+import com.typesafe.config.ConfigFactory
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
+import org.scalatest._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+object DockerComposeTag extends Tag("DockerComposeTag")
+
+class ServiceSpec extends FlatSpec with Matchers with OptionValues {
+
+  "composer service" should "compose an email" taggedAs DockerComposeTag in {
+    createKafkaTopics()
+    uploadTemplateToS3()
+    waitForKafkaConsumerToSettle()
+    sendOrchestratedEmailEvent()
+    verifyComposedEmailEvent()
+    checkNoFailedEvent()
+  }
+
+  val config = ConfigFactory.load()
+  val orchestratedEmailTopic = config.getString("kafka.topics.orchestrated.email")
+  val composedEmailTopic = config.getString("kafka.topics.composed.email")
+  val failedTopic = config.getString("kafka.topics.failed")
+  val kafkaHosts = "localhost:29092"
+  val zkHosts = "localhost:32181"
+  val s3Endpoint = "http://localhost:4569"
+
+  private def createKafkaTopics(): Unit = {
+    import _root_.kafka.admin.AdminUtils
+    import _root_.kafka.utils.ZkUtils
+    val zkUtils = ZkUtils(zkHosts, 30000, 5000, isZkSecurityEnabled = false)
+
+    // Note: the app itself creates the OrchestratedEmail topic by subscribing to it
+    AdminUtils.createTopic(zkUtils, composedEmailTopic, 1, 1)
+    AdminUtils.createTopic(zkUtils, failedTopic, 1, 1)
+  }
+
+  private def waitForKafkaConsumerToSettle(): Unit = {
+    Thread.sleep(5000L) // :(
+  }
+
+  private def uploadTemplateToS3(): Unit = {
+    // disable chunked encoding to work around https://github.com/jubos/fake-s3/issues/164
+    val s3clientOptions = S3ClientOptions.builder().setPathStyleAccess(true).disableChunkedEncoding().build()
+
+    val s3: AmazonS3Client = new AmazonS3Client(new BasicAWSCredentials("service-test", "dummy"))
+      .withRegion(Regions.fromName(config.getString("aws.region")))
+    s3.setS3ClientOptions(s3clientOptions)
+    s3.setEndpoint(s3Endpoint)
+
+    s3.createBucket("ovo-comms-templates")
+
+    // template
+    s3.putObject("ovo-comms-templates",
+                 "service/composer-service-test/0.1/email/subject.txt",
+                 "SUBJECT {{profile.firstName}}")
+    s3.putObject("ovo-comms-templates",
+                 "service/composer-service-test/0.1/email/body.html",
+                 "{{> header}} HTML BODY {{amount}}")
+    s3.putObject("ovo-comms-templates",
+                 "service/composer-service-test/0.1/email/body.txt",
+                 "{{> header}} TEXT BODY {{amount}}")
+
+    // fragments
+    s3.putObject("ovo-comms-templates", "service/fragments/email/html/header.html", "HTML HEADER")
+    s3.putObject("ovo-comms-templates", "service/fragments/email/text/header.txt", "TEXT HEADER")
+  }
+
+  private def sendOrchestratedEmailEvent(): Unit = {
+    val orchestratedEmailSerializer = Serialization.avroSerializer[OrchestratedEmail]
+    val producer = KafkaProducer(
+      ProdConf(new StringSerializer, orchestratedEmailSerializer, bootstrapServers = kafkaHosts))
+    val event = OrchestratedEmail(
+      Metadata(
+        OffsetDateTime.now().toString,
+        UUID.randomUUID(),
+        "customer123",
+        "transaction123",
+        "composer service test",
+        "ServiceSpec",
+        canary = true,
+        None
+      ),
+      CommManifest(
+        CommType.Service,
+        "composer-service-test",
+        "0.1"
+      ),
+      "chris.birchall@ovoenergy.com",
+      CustomerProfile(
+        "Chris",
+        "Birchall"
+      ),
+      Map(
+        "amount" -> "1.23"
+      )
+    )
+    val future = producer.send(new ProducerRecord(orchestratedEmailTopic, event))
+    val result = Await.result(future, atMost = 5.seconds)
+    println(s"Sent Kafka message: $result")
+  }
+
+  private def verifyComposedEmailEvent(): Unit = {
+    val composedEmailDeserializer = Serialization.avroDeserializer[ComposedEmail]
+    val consumer = KafkaConsumer(
+      ConsConf(new StringDeserializer,
+               composedEmailDeserializer,
+               groupId = "test",
+               bootstrapServers = "127.0.0.1:29092"))
+    consumer.subscribe(util.Arrays.asList(composedEmailTopic))
+    val records = consumer.poll(10000L)
+    try {
+      records.count() should be(1)
+      val event = records.iterator().next().value().value
+
+      event.subject should be("SUBJECT Chris")
+      event.htmlBody should be("HTML HEADER HTML BODY 1.23")
+      event.textBody should be(Some("TEXT HEADER TEXT BODY 1.23"))
+      event.sender should be("Ovo Energy <no-reply@ovoenergy.com>")
+      event.metadata.transactionId should be("transaction123")
+      event.metadata.customerId should be("customer123")
+    } finally {
+      consumer.commitSync()
+    }
+  }
+
+  private def checkNoFailedEvent(): Unit = {
+    val composedEmailDeserializer = Serialization.avroDeserializer[Failed]
+    val consumer = KafkaConsumer(
+      ConsConf(new StringDeserializer, composedEmailDeserializer, groupId = "test", bootstrapServers = kafkaHosts))
+    consumer.subscribe(util.Arrays.asList(failedTopic))
+    val records = consumer.poll(1000L)
+    try {
+      records.count() should be(0)
+    } finally {
+      consumer.commitSync()
+    }
+  }
+
+}

--- a/src/test/scala/com/ovoenergy/comms/ServiceTestIT.scala
+++ b/src/test/scala/com/ovoenergy/comms/ServiceTestIT.scala
@@ -23,7 +23,7 @@ import scala.concurrent.duration._
 
 object DockerComposeTag extends Tag("DockerComposeTag")
 
-class ServiceSpec extends FlatSpec with Matchers with OptionValues with BeforeAndAfterAll {
+class ServiceTestIT extends FlatSpec with Matchers with OptionValues with BeforeAndAfterAll {
 
   behavior of "composer service"
 


### PR DESCRIPTION
Set up the following environment using docker-compose:

* the service itself
* Kafka and ZooKeeper
* a fake S3 API
* an SSL proxy for S3 (shouldn't actually be necessary, but sticking a proxy between the service and S3 was the only way I could get things working)

Once all that is up and running, the test does the following:

1. Create the required Kafka topics and upload a template to S3
2. Happy path: send a valid OrchestratedEmail message to Kafka, wait for a ComposedEmail message to appear and verify its contents
3. Unhappy path: send an invalid message and verify that a Failed message appears

Other changes:

* Get CircleCI to install newer docker and docker-compose versions before running the tests
* Use sbt-docker-compose's variable substitution to inject the host machine's IP address into the docker-compose.yml because docker on OSX is an idiot. This seems to work fine on CircleCI as well.
* Improve error handling in the Interpreter