### PR TITLE
Disable Handlebars template cache

### DIFF
--- a/src/main/scala/com/ovoenergy/comms/Mustache.scala
+++ b/src/main/scala/com/ovoenergy/comms/Mustache.scala
@@ -1,3 +1,3 @@
 package com.ovoenergy.comms
 
-case class Mustache(content: String)
+case class Mustache(content: String) extends AnyVal


### PR DESCRIPTION
This was causing buggy behaviour because the templates retrieved from
the cache held references to the `Handlebars` instance that created them.
This `Handlebars` instance may be different to the one currently in use,
which causes all manner of problems, e.g. the `Helper` that tracks
missing keys no longer works.

I explored a few options to work around the problem but couldn't find
anything that was both thread-safe and vaguely understandable. Simplest
solution for now is to disable the cache. This means that all Mustache
templates will be re-compiled for every email composition. We can
revisit this if it becomes a performance issue.