### PR TITLE
Change Mustache context key of recipient email address

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oF", "-u", testReports
 resolvers += Resolver.bintrayRepo("ovotech", "maven")
 resolvers += Resolver.bintrayRepo("cakesolutions", "maven")
 
-val kafkaMessagesVersion = "0.0.12"
+val kafkaMessagesVersion = "0.0.14"
 libraryDependencies ++= Seq(
   "com.ovoenergy" %% "comms-kafka-messages" % kafkaMessagesVersion,
   "com.ovoenergy" %% "comms-kafka-serialisation" % kafkaMessagesVersion,

--- a/src/main/scala/com/ovoenergy/comms/email/Composer.scala
+++ b/src/main/scala/com/ovoenergy/comms/email/Composer.scala
@@ -34,9 +34,13 @@ object Composer {
 
   def program(event: OrchestratedEmail): Composer[ComposedEmail] = {
     for {
-      template <- retrieveTemplate(Email, event.commManifest)
-      rendered <- render(event.commManifest, template, event.data, event.customerProfile, event.recipientEmailAddress)
-      sender <- lookupSender(template, event.commManifest.commType)
+      template <- retrieveTemplate(Email, event.metadata.commManifest)
+      rendered <- render(event.metadata.commManifest,
+                         template,
+                         event.templateData,
+                         event.customerProfile,
+                         event.recipientEmailAddress)
+      sender <- lookupSender(template, event.metadata.commManifest.commType)
     } yield buildEvent(event, rendered, sender)
   }
 

--- a/src/test/scala/com/ovoenergy/comms/RenderingSpec.scala
+++ b/src/test/scala/com/ovoenergy/comms/RenderingSpec.scala
@@ -93,12 +93,12 @@ class RenderingSpec extends FlatSpec with Matchers with EitherValues {
     result.textBody should be(Some("TEXT HEADER Joe 1.23 TEXT BODY Joe 1.23 TEXT FOOTER Joe 1.23"))
   }
 
-  it should "add the recipient email address to the customer profile" in {
-    val manifest = CommManifest(CommType.Service, "profile-email-address", "0.1")
+  it should "make the recipient email address available to the email template as 'recipient.emailAddress'" in {
+    val manifest = CommManifest(CommType.Service, "recipient-email-address", "0.1")
     val template = EmailTemplate(
       sender = None,
       subject = Mustache("SUBJECT"),
-      htmlBody = Mustache("HTML BODY {{profile.emailAddress}}"),
+      htmlBody = Mustache("HTML BODY {{recipient.emailAddress}}"),
       textBody = None,
       htmlFragments = Map.empty,
       textFragments = Map.empty

--- a/src/test/scala/com/ovoenergy/comms/ServiceTestIT.scala
+++ b/src/test/scala/com/ovoenergy/comms/ServiceTestIT.scala
@@ -183,12 +183,12 @@ class ServiceTestIT extends FlatSpec with Matchers with OptionValues with Before
         UUID.randomUUID().toString,
         "customer123",
         "transaction123",
+        commManifest,
         "composer service test",
         "ServiceSpec",
         canary = true,
         None
       ),
-      commManifest,
       "chris.birchall@ovoenergy.com",
       CustomerProfile(
         "Chris",

--- a/src/test/scala/com/ovoenergy/comms/email/ComposerSpec.scala
+++ b/src/test/scala/com/ovoenergy/comms/email/ComposerSpec.scala
@@ -38,15 +38,15 @@ class ComposerSpec extends FlatSpec with Matchers {
       eventId = UUID.randomUUID().toString,
       customerId = "123-chris",
       traceToken = "abc",
+      commManifest = CommManifest(CommType.Service, "test-template", "0.1"),
       friendlyDescription = "test message",
       source = "test",
       canary = true,
       sourceMetadata = None
     ),
-    commManifest = CommManifest(CommType.Service, "test-template", "0.1"),
     recipientEmailAddress = "chris@foo.com",
     customerProfile = CustomerProfile("Joe", "Bloggs"),
-    data = Map.empty
+    templateData = Map.empty
   )
 
   it should "compose an email" in {


### PR DESCRIPTION
It was `profile.emailAddress`, it is now `recipient.emailAddress`.

This requires a change to the template footer on S3. Will do that now.

Also bump comms-kafka-messages