### PR TITLE
Upgrade comms-kafka-serialisation, circe, cats

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,13 +13,14 @@ resolvers += Resolver.bintrayRepo("cakesolutions", "maven")
 
 libraryDependencies ++= Seq(
   "com.ovoenergy" %% "comms-kafka-messages" % "0.0.29",
-  "com.ovoenergy" %% "comms-kafka-serialisation" % "1.0",
+  "com.ovoenergy" %% "comms-kafka-serialisation" % "2.0",
+  "io.circe" %% "circe-generic" % "0.7.0",
   "com.github.jknack" % "handlebars" % "4.0.6",
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.57",
   "net.cakesolutions" %% "scala-kafka-client" % "0.10.0.0",
   "com.typesafe.akka" %% "akka-stream-kafka" % "0.13",
   "com.typesafe.akka" %% "akka-slf4j" % "2.3.14",
-  "org.typelevel" %% "cats-free" % "0.8.1",
+  "org.typelevel" %% "cats-free" % "0.9.0",
   "com.chuusai" %% "shapeless" % "2.3.2",
   "ch.qos.logback" % "logback-classic" % "1.1.7",
   "io.logz.logback" % "logzio-logback-appender" % "1.0.11",

--- a/src/main/scala/com/ovoenergy/comms/Main.scala
+++ b/src/main/scala/com/ovoenergy/comms/Main.scala
@@ -19,6 +19,8 @@ import com.ovoenergy.comms.kafka.Kafka
 import com.ovoenergy.comms.model.{ComposedEmail, Failed, OrchestratedEmail}
 import com.ovoenergy.comms.repo.AmazonS3ClientWrapper
 import com.ovoenergy.comms.serialisation.Serialisation._
+import com.ovoenergy.comms.serialisation.Decoders._
+import io.circe.generic.auto._
 import com.typesafe.config.ConfigFactory
 import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
 import org.slf4j.LoggerFactory

--- a/src/test/scala/com/ovoenergy/comms/ServiceTestIT.scala
+++ b/src/test/scala/com/ovoenergy/comms/ServiceTestIT.scala
@@ -12,6 +12,8 @@ import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.{AmazonS3Client, S3ClientOptions}
 import com.ovoenergy.comms.model._
 import com.ovoenergy.comms.serialisation.Serialisation._
+import com.ovoenergy.comms.serialisation.Decoders._
+import io.circe.generic.auto._
 import com.typesafe.config.{ConfigFactory, ConfigParseOptions, ConfigResolveOptions}
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.producer.ProducerRecord


### PR DESCRIPTION
This means we are now using circe to deserialise JSON-encoded Avro messages