### PR TITLE
HTTP healthcheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# IntelliJ
+.idea/
+*.iws
+out/
+.idea_modules/
+atlassian-ide-plugin.xml
+
+# sbt and scala
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+.history
+.cache
+.lib/
+*.class
+*.log
+
+#Mac
+.DS_Store

--- a/.init_env.sh
+++ b/.init_env.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+export AWS_ACCOUNT_ID=852955754882

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "composer"
 organization := "com.ovoenergy"
 
 scalaVersion := "2.12.4"
-scalacOptions := Seq("-unchecked", "-deprecation", "-feature", "-encoding", "utf8")
+scalacOptions := Seq("-unchecked", "-deprecation", "-feature", "-encoding", "utf8", "-Ypartial-unification")
 
 // Make ScalaTest write test reports that CircleCI understands
 val testReportsDir = sys.env.getOrElse("CI_REPORTS", "target/reports")
@@ -25,6 +25,7 @@ resolvers := Resolver.withDefaultResolvers(
 
 val kafkaMessagesVersion = "1.38"
 val kafkaSerialisationVersion = "3.4"
+val Http4sVersion = "0.17.5"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-stream-kafka" % "0.17",
@@ -32,12 +33,17 @@ libraryDependencies ++= Seq(
   "com.ovoenergy" %% "comms-kafka-serialisation" % kafkaSerialisationVersion,
   "com.ovoenergy" %% "comms-kafka-helpers"       % kafkaSerialisationVersion,
   "io.circe" %% "circe-generic" % "0.7.0",
+  "io.circe" %% "circe-literal" % "0.7.0",
   "com.github.jknack" % "handlebars" % "4.0.6",
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.57",
   "com.typesafe.akka" %% "akka-slf4j" % "2.4.18",
   "org.typelevel" %% "cats-free" % "0.9.0",
   "com.chuusai" %% "shapeless" % "2.3.2",
   "com.squareup.okhttp3" % "okhttp" % "3.4.2",
+  "org.http4s"      %% "http4s-blaze-server" % Http4sVersion,
+  "org.http4s"      %% "http4s-circe"        % Http4sVersion,
+  "org.http4s"      %% "http4s-dsl"          % Http4sVersion,
+  "org.http4s"      %% "http4s-blaze-client" % Http4sVersion % Test,
   "com.fortysevendeg" %% "scalacheck-toolbox-datetime" % "0.2.1" % Test,
   "ch.qos.logback" % "logback-classic" % "1.1.7",
   "io.logz.logback" % "logzio-logback-appender" % "1.0.11",
@@ -45,8 +51,8 @@ libraryDependencies ++= Seq(
   "com.ovoenergy" %% "comms-templates" % "0.11",
   "com.github.alexarchambault"  %% "scalacheck-shapeless_1.13" % "1.1.4" % Test exclude("org.slf4j", "log4j-over-slf4j"),
   "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
-  "com.whisk"                  %% "docker-testkit-scalatest" % "0.9.3" % ServiceTest,
-  "com.whisk"                  %% "docker-testkit-impl-docker-java" % "0.9.3" % ServiceTest,
+  "com.whisk"                  %% "docker-testkit-scalatest" % "0.9.6" % ServiceTest,
+  "com.whisk"                  %% "docker-testkit-impl-docker-java" % "0.9.6" % ServiceTest,
   "com.ovoenergy" %% "comms-kafka-test-helpers" % kafkaSerialisationVersion % ServiceTest,
   "org.scalatest" %% "scalatest" % "3.0.1" % Test,
   "org.apache.kafka" %% "kafka" % "0.10.2.1"  % Test exclude ("org.scalatest", "scalatest"),

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -35,3 +35,8 @@ doc-raptor {
   apiKey = ""
   test = true
 }
+
+http-server {
+  host: 0.0.0.0
+  port: 8080
+}

--- a/src/main/scala/com/ovoenergy/comms/composer/http/AdminRestApi.scala
+++ b/src/main/scala/com/ovoenergy/comms/composer/http/AdminRestApi.scala
@@ -1,0 +1,16 @@
+package com.ovoenergy.comms.composer.http
+
+import org.http4s.HttpService
+import org.http4s._
+import org.http4s.dsl._
+import org.http4s.circe._
+import io.circe.literal._
+
+trait AdminRestApi {
+
+  def adminService: HttpService = HttpService {
+    case GET -> Root / "admin" / "health" =>
+      Ok(json"""{"status": "healthy"}""")
+  }
+
+}

--- a/src/main/scala/com/ovoenergy/comms/composer/http/HttpServerConfig.scala
+++ b/src/main/scala/com/ovoenergy/comms/composer/http/HttpServerConfig.scala
@@ -1,0 +1,15 @@
+package com.ovoenergy.comms.composer.http
+
+import com.typesafe.config.Config
+import pureconfig._
+import pureconfig.error.ConfigReaderFailures
+
+case class HttpServerConfig(host: String, port: Int)
+
+object HttpServerConfig {
+
+  def fromConfig(config: Config): Either[ConfigReaderFailures, HttpServerConfig] = loadConfig[HttpServerConfig](config)
+
+  def unsafeFromConfig(config: Config): HttpServerConfig = fromConfig(config)
+    .fold(error => throw new RuntimeException(s"""Error parsing the config: ${error.toList.mkString(",")}"""), identity)
+}

--- a/src/main/scala/com/ovoenergy/comms/composer/rendering/templating/PrintTemplateRendering.scala
+++ b/src/main/scala/com/ovoenergy/comms/composer/rendering/templating/PrintTemplateRendering.scala
@@ -28,13 +28,13 @@ object PrintTemplateRendering extends Rendering {
     val address = orchestratedPrint.address
 
     val addressMap = Map(
-      "line1" -> Some(address.line1),
-      "town" -> Some(address.town),
-      "postcode" -> Some(address.postcode),
-      "line2" -> address.line2,
-      "county" -> address.county,
-      "country" -> address.country
-    ) collect { case (k, Some(v)) => (k, v) }
+        "line1" -> Some(address.line1),
+        "town" -> Some(address.town),
+        "postcode" -> Some(address.postcode),
+        "line2" -> address.line2,
+        "county" -> address.county,
+        "country" -> address.country
+      ) collect { case (k, Some(v)) => (k, v) }
 
     val customerAddressMap: Map[String, Map[String, String]] = Map("address" -> addressMap)
 

--- a/src/servicetest/scala/servicetest/HttpServiceTest.scala
+++ b/src/servicetest/scala/servicetest/HttpServiceTest.scala
@@ -1,0 +1,56 @@
+package servicetest
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.s3.{AmazonS3Client, S3ClientOptions}
+import com.ovoenergy.comms.composer.http.HttpServerConfig
+import com.ovoenergy.comms.helpers.Kafka
+import com.ovoenergy.comms.model
+import com.ovoenergy.comms.model._
+import com.ovoenergy.comms.model.email.OrchestratedEmailV3.schemaFor
+import com.ovoenergy.comms.model.email._
+import com.ovoenergy.comms.model.sms._
+import com.ovoenergy.comms.testhelpers.KafkaTestHelpers._
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.scalatest.{Failed => _, _}
+import shapeless.Coproduct
+
+import scala.concurrent.duration._
+import scala.language.reflectiveCalls
+import org.http4s._
+import org.http4s.client.Client
+import org.http4s.client.blaze.PooledHttp1Client
+import org.http4s.dsl._
+
+class HttpServiceTest
+    extends FlatSpec
+    with Matchers
+    with OptionValues
+    with BeforeAndAfterAll
+    with DockerIntegrationTest {
+
+  implicit val config: Config = ConfigFactory.load("servicetest.conf")
+
+  implicit val patience: PatienceConfig = PatienceConfig(5.minutes, 1.second)
+
+  behavior of "Composer HTTP service"
+
+  it should "respond OK to /admin/health" in newHttpClient { client =>
+    whenReady(client.status(Request(GET, Uri.unsafeFromString(s"$composerHttpEndpoint/admin/health"))).unsafeRunAsyncFuture()) { status =>
+      status shouldBe Ok
+    }
+  }
+
+  def newHttpClient[A](f: Client => A): A = {
+    val httpClient: Client = PooledHttp1Client()
+    try {
+      f(httpClient)
+    } finally {
+      httpClient.shutdownNow()
+    }
+  }
+}

--- a/src/test/scala/com/ovoenergy/comms/composer/http/AdminRestApiSpec.scala
+++ b/src/test/scala/com/ovoenergy/comms/composer/http/AdminRestApiSpec.scala
@@ -1,0 +1,15 @@
+package com.ovoenergy.comms.composer.http
+
+import org.scalatest.{FlatSpec, Matchers}
+import org.http4s.dsl._
+import org.http4s._
+
+class AdminRestApiSpec extends FlatSpec with Matchers with AdminRestApi {
+
+  "admin/health" should "return HTTP 200 when the service is healthy" in {
+    val response = adminService.run(Request(GET, Uri.unsafeFromString("/admin/health"))).unsafeRun().orNotFound
+
+    response.status shouldBe Ok
+  }
+
+}


### PR DESCRIPTION
Add a dummy admin/health endpoint to allow the load balancer monitoring the status of the service

It uses the last stable version of http4s as the new one need to upgrade a bunch of things like cats and shapeless.