### PR TITLE
Avoid using kafka consumer stream

### DIFF
--- a/src/main/scala/com/ovoenergy/comms/composer/kafka/Kafka.scala
+++ b/src/main/scala/com/ovoenergy/comms/composer/kafka/Kafka.scala
@@ -187,7 +187,7 @@ object Kafka {
         producer <- producerStream[F].using(producerSettings[Out])
         failedProducer <- producerStream[F].using(producerSettings[FailedV3])
         feedbackProducer <- producerStream[F].using(producerSettings[Feedback])
-        _ <- consumer.stream
+        _ <- consumer.partitionedStream.parJoinUnbounded
           .mapAsync(25) { (message: CommittableMessage[F, String, In]) =>
             val logConsumed =
               log.info(consumerRecordLoggable(message.record): _*)("Consumed Kafka message")


### PR DESCRIPTION
This will avoid the fs2-kafka to abort partitions that do not receive data in time. It just processes all the partitions in parallel.